### PR TITLE
[BIA-1058] Create the xref tables necessary to relate the ODS to CEDS

### DIFF
--- a/CEDS/0000-Schema-Xref-Create.sql
+++ b/CEDS/0000-Schema-Xref-Create.sql
@@ -1,0 +1,10 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+IF NOT EXISTS (SELECT [name]
+	FROM sys.schemas
+    WHERE [name] = 'xref' )
+    EXEC('CREATE SCHEMA [xref]')
+GO

--- a/CEDS/0001-Table-EdFiTableReference-Create.sql
+++ b/CEDS/0001-Table-EdFiTableReference-Create.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE TABLE xref.EdFiTableReference ( 
+	EdFiTableId INT PRIMARY KEY IDENTITY(1,1) NOT NULL,
+	EdFiTableName VARCHAR(250) NOT NULL
+)

--- a/CEDS/0002-Table-EdFiTableInformation-Create.sql
+++ b/CEDS/0002-Table-EdFiTableInformation-Create.sql
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE TABLE xref.EdFiTableInformation (
+	EdFiDescriptorId INT NOT NULL,
+	EdFiCodeValue VARCHAR(50) NOT NULL,
+	EdFactsCode VARCHAR(50) NOT NULL,
+	EdFiTableId INT NOT NULL,
+	CONSTRAINT FK_EdfiTableReference_EdfiTableInformation
+	FOREIGN KEY (EdFiTableId)
+	REFERENCES xref.EdfiTableReference(EdFiTableId)
+)

--- a/CEDS/0003-Table-EdfiTableReference-Insert.sql
+++ b/CEDS/0003-Table-EdfiTableReference-Insert.sql
@@ -1,0 +1,21 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+INSERT INTO xref.EdfiTableReference VALUES
+	('xref.LEAType'),
+	('xref.SchoolType'),
+	('xref.OperationalStatus'),
+	('xref.GradeLevels'),
+	('xref.BasisOfExit'),
+	('xref.DisabilityDescriptor'),
+	('xref.EducationalEnvironmentType'),
+	('xref.EconomicDisadvantageStatus'),
+	('xref.HomelessnessStatus'),
+	('xref.EnglishLearnerStatus'),
+	('xref.MigrantStatus'),
+	('xref.MilitaryConnectedStudentIndicator'),
+	('xref.HomelessPrimaryNighttimeResidence'),
+	('xref.HomelessUnaccompaniedYouthStatus'),
+	('xref.Sex')

--- a/CEDS/0004-Table-EdfiTableInformation-Insert.sql
+++ b/CEDS/0004-Table-EdfiTableInformation-Insert.sql
@@ -1,0 +1,25 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+INSERT INTO xref.EdfiTableInformation (EdFiDescriptorId, EdFiCodeValue, EdFactsCode, EdFiTableId)
+VALUES
+	( -1, '-1', 'MISSING', 4),
+	(471, 'Preschool/Prekindergarten', 'PK', 4),
+	(467, 'Kindergarten', 'KG', 4),
+	(463, 'First grade', '3', 4),
+	(472, 'Second grade', '4', 4),
+	(476, 'Third grade', '5', 4),
+	(464, 'Fourth grade', '6', 4),
+	(462, 'Fifth grade', '7', 4),
+	(474, 'Sixth grade', '8', 4),
+	(473, 'Seventh grade', '9', 4),
+	(460, 'Eighth grade', '10', 4),
+	(468, 'Ninth grade', '11', 4),
+	(475, 'Tenth grade', '10', 4),
+	(461, 'Eleventh grade', '11', 4),
+	(477, 'Twelfth grade', '12', 4),
+	(470, 'Postsecondary', 'HS', 4),
+	(478, 'Ungraded', 'UG', 4),
+	(458, 'Adult Education', 'AE', 4)


### PR DESCRIPTION
 It simplified the sixteen tables into two, one of which has the table name relationship and the other handles the data.

- `Created CEDS directory.`
- `Created 0000-Schema-Xref-Create.`
- `Created 0001-Table-EdFiTableReference-Create.`
- `Created 0002-Table-EdFiTableInformation-Create.`
- `Created 0003-Table-EdfiTableReference-Insert.`
- `Created 0004-Table-EdfiTableInformation-Insert.`